### PR TITLE
Extracted releases counter to a common function

### DIFF
--- a/armory/armory.go
+++ b/armory/armory.go
@@ -96,6 +96,7 @@ func unauthenticatedTestSuites() map[string][]pluginkit.TestSet {
 		"dev": {
 			QA_01,
 			BR_02,
+			BR_06,
 		},
 		"maturity_1": {},
 		"maturity_2": {},

--- a/armory/br-02.go
+++ b/armory/br-02.go
@@ -23,18 +23,7 @@ func BR_02() (string, pluginkit.TestSetResult) {
 }
 
 func BR_02_T01() pluginkit.TestResult {
-	releases := Data.Rest().Repo.Releases
-
-	testResult := pluginkit.TestResult{
-		Description: "Discover all releases on the repository",
-		Function:    utils.CallerPath(0),
-		Passed:      true,
-		Value:       releases,
-		Message:     fmt.Sprintf("Releases found: %v", len(releases)),
-	}
-
-	// TODO: Use this section to write a single step or test that contributes to BR_01
-	return testResult
+	return countReleases()
 }
 
 func BR_02_T02() pluginkit.TestResult {

--- a/armory/br-06.go
+++ b/armory/br-06.go
@@ -34,7 +34,7 @@ func BR_06_T02() pluginkit.TestResult {
 	}
 
 	if !Authenticated {
-		// TODO: This be a REST call, just grab the first releases entry "body" instead of graphql latest "description"
+		// TODO: This could be a REST call, just grab the first releases entry "body" instead of graphql latest "description"
 		testResult.Passed = false
 		testResult.Message = "Not authenticated, cannot continue"
 	} else {

--- a/armory/br-06.go
+++ b/armory/br-06.go
@@ -24,25 +24,24 @@ func BR_06() (string, pluginkit.TestSetResult) {
 }
 
 func BR_06_T01() pluginkit.TestResult {
-	releaseCount := Data.GraphQL().Repository.Releases.TotalCount
-
-	return pluginkit.TestResult{
-		Description: "Checking whether project has releases, passing if no releases are present",
-		Function:    utils.CallerPath(0),
-		Passed:      true,
-		Message:     fmt.Sprintf("Releases Found: %v", releaseCount),
-	}
+	return countReleases()
 }
 
 func BR_06_T02() pluginkit.TestResult {
-	releaseDescription := Data.GraphQL().Repository.LatestRelease.Description
-	contains := (strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog"))
-
 	testResult := pluginkit.TestResult{
 		Description: "Checking whether project has releases, passing if no releases are present",
 		Function:    utils.CallerPath(0),
-		Passed:      contains,
-		Message:     fmt.Sprintf("Change Log Found in Latest Release: %v", contains),
+	}
+
+	if !Authenticated {
+		// TODO: This be a REST call, just grab the first releases entry "body" instead of graphql latest "description"
+		testResult.Passed = false
+		testResult.Message = "Not authenticated, cannot continue"
+	} else {
+		releaseDescription := Data.GraphQL().Repository.LatestRelease.Description
+		contains := (strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog"))
+		testResult.Passed = contains
+		testResult.Message = fmt.Sprintf("Change Log Found in Latest Release: %v", contains)
 	}
 	return testResult
 }

--- a/armory/common-tests.go
+++ b/armory/common-tests.go
@@ -1,0 +1,23 @@
+package armory
+
+import (
+	"fmt"
+
+	"github.com/privateerproj/privateer-sdk/pluginkit"
+	"github.com/privateerproj/privateer-sdk/utils"
+)
+
+func countReleases() pluginkit.TestResult {
+	releases := Data.Rest().Repo.Releases
+
+	testResult := pluginkit.TestResult{
+		Description: "Counting the number of releases on the repository",
+		Function:    utils.CallerPath(1),
+		Passed:      true,
+		Value:       releases,
+		Message:     fmt.Sprintf("Releases found: %v", len(releases)),
+	}
+
+	// TODO: Use this section to write a single step or test that contributes to BR_01
+	return testResult
+}


### PR DESCRIPTION
first time we've needed to do this! note that the function value is now needing to get the caller path from one up in the stack: `Function:    utils.CallerPath(1),`


## Output

```
2025-01-17T03:17:12.605-0600 [INFO]  OSPS-BR-02: Non-unique release names: 0
2025-01-17T03:17:12.605-0600 [ERROR] OSPS-BR-06: Not authenticated, cannot continue
2025-01-17T03:17:12.609-0600 [INFO]  2025/01/17 03:17:12 dev: 2/3 test sets succeeded
```